### PR TITLE
Osm/feature extraction extension

### DIFF
--- a/imd_pipeline/process/open_street_map.py
+++ b/imd_pipeline/process/open_street_map.py
@@ -24,7 +24,7 @@ BUFFER_DISTANCES = [
 ]
 
 SELECTED_NEAREST_POI = [
-    'hospital', 'pharmacy', 'school', 'kindergarten',
+    'shop', 'hospital', 'pharmacy', 'school', 'kindergarten',
     'college', 'university', 'bank', 'atm', 'ice_cream',
     'fast_food', 'pub', 'bar', 'nightclub', 'stripclub',
     'gambling', 'bicycle_parking', 'cinema', 'theatre',


### PR DESCRIPTION
OSM feature extraction extension currently includes extending nearest_poi from just shops to include a variety of poi and similarly for ratio of fastfood to dining poi. Noticing a lot of null value prevalence with ratio features because in cases where the count of a poi is 0, it cannot be used as a denominator. How this should be handled I am undecided on and I think could do with some discussion from the group.