### PR TITLE
Osm/border extension

### DIFF
--- a/imd_pipeline/fetch/open_street_map.py
+++ b/imd_pipeline/fetch/open_street_map.py
@@ -1,45 +1,62 @@
 from loguru import logger
 from project_paths import paths
-import requests
+import json
 
 from imd_pipeline.utils.http import cached_fetch_json, create_session
 
-def get_area_bbox(area_name: str = "Bristol") -> tuple[float, float, float, float]:
-    """
-    Get the bounding box of a city from Overpass API.
+def get_area_bbox(force_refresh: bool = False) -> tuple[float, float, float, float]:
+    """Fetches the bounding box for Bristol using the Overpass API."""
 
-    Returns:
-        (min_lat, min_lon, max_lat, max_lon)
-    """
-    overpass_url = "https://overpass-api.de/api/interpreter"
-    query = f"""
+    query = """
     [out:json];
-    area["name"="{area_name}"]->.a;
-    .a->.searchArea;
-    out geom;
+    relation["ISO3166-2"="GB-BST"];
+    out bb;
     """
-    output_path = paths.data_raw / "osm" / f"{area_name}_bbox.json"
-    cached_fetch_json(
-        url=overpass_url,
+
+    output_path = paths.data_raw / "osm" / "bristol_bbox.json"
+
+    response_path = cached_fetch_json(
+        url="https://overpass-api.de/api/interpreter",
         output_path=output_path,
         session=create_session(),
-        force_refresh=False,
+        force_refresh=force_refresh,
         params={"data": query},
     )
 
-    data = requests.get(overpass_url, params={"data": query}).json()
-    lats = []
-    lons = []
-    for elem in data.get("elements", []):
-        if "geometry" in elem:
-            for node in elem["geometry"]:
-                lats.append(node["lat"])
-                lons.append(node["lon"])
-    return min(lats), min(lons), max(lats), max(lons)
+    with open(response_path) as f:
+        data = json.load(f)
 
+    bounds = data["elements"][0]["bounds"]
 
+    return (
+        bounds["minlat"],
+        bounds["minlon"],
+        bounds["maxlat"],
+        bounds["maxlon"],
+    )
 
-def fetch(force_refresh: bool = False):
+def expand_bbox(bbox: tuple[float, float, float, float], buffer_m: float = 5000) -> tuple[float, float, float, float]:
+    """
+    Expands a bounding box by buffer meters (approximate, using degrees conversion).
+
+    Args:
+        bbox: (min_lat, min_lon, max_lat, max_lon)
+        buffer_m: buffer in meters
+
+    Returns:
+        expanded bounding box
+    """
+    
+    buffer_deg = buffer_m / 111000 # Rough approximation: 1 degree latitude ~ 111 km
+    min_lat, min_lon, max_lat, max_lon = bbox
+    return (
+        min_lat - buffer_deg,
+        min_lon - buffer_deg,
+        max_lat + buffer_deg,
+        max_lon + buffer_deg,
+    )
+
+def fetch(force_refresh: bool = False, buffer_m: float = 5000):
     """Fetches Bristol OSM data from the Overpass API using cached_fetch_json,
     which skips the download if the file already exists.
 
@@ -47,6 +64,7 @@ def fetch(force_refresh: bool = False):
 
     Args:
         force_refresh: If True, re-fetch even if the file exists.
+        buffer_m: Buffer in meters to expand the bounding box around Bristol.
 
     Returns:
         Path to the saved JSON response.
@@ -58,19 +76,21 @@ def fetch(force_refresh: bool = False):
 
     output_path = paths.data_raw / "osm" / "overpass_response.json"
 
+    min_lat, min_lon, max_lat, max_lon = expand_bbox(get_area_bbox(), buffer_m)
+
     overpass_url = "https://overpass-api.de/api/interpreter"
-    bristol_data_query = """
+    bristol_data_query = f"""
 [out:json];
 area["ISO3166-2"="GB-BST"]->.bristol;
 (
-    node["amenity"](area.bristol);
-    way["amenity"](area.bristol);
-    node["shop"](area.bristol);
-    way["shop"](area.bristol);
-    node["landuse"](area.bristol);
-    way["landuse"](area.bristol);
-    node["highway"](area.bristol);
-    way["highway"](area.bristol);
+        node["amenity"]({min_lat},{min_lon},{max_lat},{max_lon});
+        way["amenity"]({min_lat},{min_lon},{max_lat},{max_lon});
+        node["shop"]({min_lat},{min_lon},{max_lat},{max_lon});
+        way["shop"]({min_lat},{min_lon},{max_lat},{max_lon});
+        node["landuse"]({min_lat},{min_lon},{max_lat},{max_lon});
+        way["landuse"]({min_lat},{min_lon},{max_lat},{max_lon});
+        node["highway"]({min_lat},{min_lon},{max_lat},{max_lon});
+        way["highway"]({min_lat},{min_lon},{max_lat},{max_lon});
 );
 out geom;
 """


### PR DESCRIPTION
Amended the fetch script for OSM data to go beyond Bristol city's shape to better capture aggregations for border lsoas. This PR is to solve issue 11. 

The previous solution which gets Bristol's shape exactly is replaced by two functions which first get a box to capture the city in using the smallest possible rectangle and then extend these boundaries by a function argument value (default is 5km).

The previous solution felt more elegant in that it gets the exact shape of Bristol. However, extending these lines by 5km from a central point seems more difficult than initially thought. Also, feature extraction is already distance based, therefore the shape of the fetched raw map is not necessarily relevant as long as it covers the city and at least the specified buffer distance beyond it.