### PR TITLE
added and tested date param for osm fetch

### DIFF
--- a/imd_pipeline/fetch/open_street_map.py
+++ b/imd_pipeline/fetch/open_street_map.py
@@ -85,7 +85,7 @@ def fetch(force_refresh: bool = False, buffer_m: float = 5000, snapshot_date: st
         filename = f"overpass_response_{snapshot_date}.json"
     else:
         date_clause = ""
-        filename = "overpass_response_latest.json"
+        filename = "overpass_response.json"
 
     output_path = paths.data_raw / "osm" / filename
 
@@ -118,4 +118,4 @@ out geom;
 
 
 if __name__ == "__main__":
-    fetch(snapshot_date="2024-01-01")
+    fetch()

--- a/imd_pipeline/process/open_street_map.py
+++ b/imd_pipeline/process/open_street_map.py
@@ -283,11 +283,15 @@ def get_polygon(x) -> Polygon:
     return Polygon(json.loads(x).get("coordinates")[0][0])
 
 
-def process(persist_processed_file: bool = False) -> pl.LazyFrame:
+def process(persist_processed_file: bool = False, snapshot_date: str | None = None) -> pl.LazyFrame:
 
     logger.info("setting up open street map processing...")
 
-    response_file = paths.data_raw / "osm" / "overpass_response.json"
+    if snapshot_date:
+        response_file = paths.data_raw / "osm" / f"overpass_response_{snapshot_date}.json"
+    else:
+        response_file = paths.data_raw / "osm" / "overpass_response.json"
+
     with open(response_file) as file:
         data = json.load(file)
     map_elements = data.get("elements")


### PR DESCRIPTION
PR for issue 10. Expanded OSM fetch to have a snapshot date param. The parameter uses the overpass API to fetch historical OSM data from the given date. 

If a snapshot date is given, the fetched data will be saved as "overpass_response_{snapshot_date}", otherwise saved as it has been up to this point as overpass_response. So then for example, if snapshot_date is 2025-12-12 then the filename will be "overpass_response_2025-12-12".

The OSM process script has also been updated to account for this. The function now takes an optional parameter for snap_shot date and will then process the file with relevant date or overpass_response otherwise.