### PR TITLE
Multi city/geo lookups

### DIFF
--- a/imd_pipeline/fetch/geography_lookup.py
+++ b/imd_pipeline/fetch/geography_lookup.py
@@ -3,7 +3,7 @@ from io import BytesIO
 import pandas as pd
 from loguru import logger
 from project_paths import paths
-
+import json
 from imd_pipeline.utils.http import create_session
 
 
@@ -15,20 +15,38 @@ def fetch(force_refresh: bool = False):
         logger.debug("cache hit", path=output_path)
         return
 
-    url = "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/Lower_layer_Super_Output_Areas_December_2021_Boundaries_EW_BGC_V5/FeatureServer/0/query?where=1%3D1&outFields=LSOA21CD,LSOA21NM,LSOA21NMW,LAT,LONG,Shape__Area,Shape__Length&outSR=4326&f=json"
+    url = "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/Lower_layer_Super_Output_Areas_December_2021_Boundaries_EW_BSC_V4/FeatureServer/0/query?where=1%3D1&outFields=*&outSR=4326&f=json"
 
     session = create_session()
-    logger.info("downloading geojson", url=url)
-
-    r = session.get(url)
+    r = session.get(url, params={"returnIdsOnly": "true"})
     r.raise_for_status()
 
+    object_ids = json.loads((r.content).decode("utf-8"))["objectIds"]
+    logger.info(f"number of objects to fetch: {len(object_ids)}")
+
+    chunk_size = 200
+    all_features = []
+
+    # 2️⃣ fetch batches using only objectIds
+    for i in range(0, len(object_ids), chunk_size):
+        batch_ids = object_ids[i:i+chunk_size]
+
+        if (i // chunk_size + 1) % 25 == 0:
+            logger.debug(f"Fetching batch {i//chunk_size + 1}/{(len(object_ids)-1)//chunk_size + 1}")
+
+        r_batch = session.get(url, params={"objectIds": ",".join(map(str, batch_ids))})
+        r_batch.raise_for_status()
+        batch_data = json.loads(r_batch.content.decode("utf-8"))["features"]
+        all_features.extend(batch_data)
+
+    # 3️⃣ save as a single valid GeoJSON
+    geojson_data = {"type": "FeatureCollection", "features": all_features}
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(geojson_data, f)
 
-    with open(output_path, "wb") as f:
-        f.write(r.content)
-
-    logger.info("geojson saved", path=str(output_path))
+    logger.info("GeoJSON saved successfully", path=str(output_path))
 
 
 if __name__ == "__main__":

--- a/imd_pipeline/fetch/geography_lookup.py
+++ b/imd_pipeline/fetch/geography_lookup.py
@@ -9,25 +9,27 @@ from imd_pipeline.utils.http import create_session
 
 def fetch(force_refresh: bool = False):
 
-    output_path = paths.data_raw / "lookup" / "geography_lookup.parquet"
+    output_path = paths.data_raw / "lookup" / "geography_lookup.geojson"
+
     if output_path.exists() and not force_refresh:
         logger.debug("cache hit", path=output_path)
         return
 
-    url = "https://opendata.westofengland-ca.gov.uk/api/explore/v2.1/catalog/datasets/lep_lsoa_geog/exports/csv?lang=en&qv1=(bristol)&timezone=Europe%2FLondon&use_labels=true&delimiter=%2C"
+    url = "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/Lower_layer_Super_Output_Areas_December_2021_Boundaries_EW_BGC_V5/FeatureServer/0/query?where=1%3D1&outFields=LSOA21CD,LSOA21NM,LSOA21NMW,LAT,LONG,Shape__Area,Shape__Length&outSR=4326&f=json"
+
     session = create_session()
-    logger.info("downloading geography_lookup data", url=url)
+    logger.info("downloading geojson", url=url)
+
     r = session.get(url)
+    r.raise_for_status()
 
-    df: pd.DataFrame = pd.read_csv(
-        BytesIO(r.content),
-    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    logger.debug("geography_lookup data loaded", shape=df.shape)
+    with open(output_path, "wb") as f:
+        f.write(r.content)
 
-    df.to_parquet(output_path)
-    logger.info("geography_lookup data written", path=str(output_path))
+    logger.info("geojson saved", path=str(output_path))
 
 
 if __name__ == "__main__":
-    fetch()
+    fetch(force_refresh=True)

--- a/imd_pipeline/fetch/geography_lookup.py
+++ b/imd_pipeline/fetch/geography_lookup.py
@@ -27,7 +27,6 @@ def fetch(force_refresh: bool = False):
     chunk_size = 200
     all_features = []
 
-    # 2️⃣ fetch batches using only objectIds
     for i in range(0, len(object_ids), chunk_size):
         batch_ids = object_ids[i:i+chunk_size]
 
@@ -39,7 +38,6 @@ def fetch(force_refresh: bool = False):
         batch_data = json.loads(r_batch.content.decode("utf-8"))["features"]
         all_features.extend(batch_data)
 
-    # 3️⃣ save as a single valid GeoJSON
     geojson_data = {"type": "FeatureCollection", "features": all_features}
 
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/imd_pipeline/process/geography_lookup.py
+++ b/imd_pipeline/process/geography_lookup.py
@@ -22,7 +22,7 @@ def process(local_authorities: list[str]) -> pl.LazyFrame:
         geom = feat.get("geometry")
         if geom:
             # Save geometry as JSON string with "coordinates" key
-            props["geo_shape"] = json.dumps({"coordinates": geom.get("rings")})
+            props["geo_shape"] = json.dumps({"coordinates": [geom.get("rings")]})
        
         rows.append(props)
 

--- a/imd_pipeline/process/geography_lookup.py
+++ b/imd_pipeline/process/geography_lookup.py
@@ -1,11 +1,7 @@
-from turtle import pd
-
 import polars as pl
 from loguru import logger
 from project_paths import paths
-import geopandas as gpd
 import json
-from shapely.geometry import shape
 
 def process(local_authorities: list[str]) -> pl.LazyFrame:
 
@@ -19,7 +15,6 @@ def process(local_authorities: list[str]) -> pl.LazyFrame:
 
     features = geojson_data.get("features", [])
 
-
     rows = []
     for feat in features:
         props = feat.get("properties") or feat.get("attributes") or {}
@@ -31,28 +26,10 @@ def process(local_authorities: list[str]) -> pl.LazyFrame:
        
         rows.append(props)
 
-
-    # 4️⃣ Convert to DataFrame
     full_df = pl.DataFrame(rows)
 
-    pl.Config.set_tbl_cols(-1)
-    print(full_df.head())
-    print(full_df.columns)
-
-
-
     lac_filter = pl.read_csv(lac_path).filter(pl.col("local_authority_code").is_in(local_authorities)).select(pl.col("lsoa_code_21").alias("lsoa_code"), pl.col("local_authority_code"))
-    
-    
     df = full_df.join(lac_filter, left_on="LSOA21CD", right_on="lsoa_code", how="inner")
-
-
-
-    print(df.head())
-    print(df.shape)
-
-
-
 
     df = df.select([
         pl.col("LSOA21CD").alias("lsoa_code"),
@@ -62,27 +39,7 @@ def process(local_authorities: list[str]) -> pl.LazyFrame:
         pl.col("local_authority_code")
     ])
 
-    print(df.head())
-
-    return df.lazy().sink_csv(paths.data_lookup / "geography_lookup_new.csv")
-
-# for reference, the original code was:
-def process_old() -> pl.LazyFrame:
-    logger.info("processing geography lookup data", source=str(paths.data_raw / "lookup" / "geography_lookup.parquet"))
-    return (
-        pl.scan_parquet(paths.data_raw / "lookup" / "geography_lookup.parquet")
-        .select(
-            [pl.col("Geo Point").alias("geo_point"),
-             pl.col("Geo Shape").alias("geo_shape"),
-             pl.col("LSOA Code").alias("lsoa_code"),
-             pl.col("Easting").alias("easting"),
-             pl.col("Northing").alias("northing"),
-             pl.col("Longitude").alias("longitude"),
-             pl.col("Latitude").alias("latitude"),
-             pl.col("Local Authority Code").alias("local_authority_code")]
-             ).sink_csv(paths.data_lookup / "geography_lookup.csv")
-             )
-
+    return df.lazy().sink_csv(paths.data_lookup / "geography_lookup.csv")
 
 
 

--- a/imd_pipeline/process/geography_lookup.py
+++ b/imd_pipeline/process/geography_lookup.py
@@ -1,8 +1,73 @@
+from turtle import pd
+
 import polars as pl
 from loguru import logger
 from project_paths import paths
+import geopandas as gpd
+import json
+from shapely.geometry import shape
 
-def process() -> pl.LazyFrame:
+def process(local_authorities: list[str]) -> pl.LazyFrame:
+
+    input_path = paths.data_raw / "lookup" / "geography_lookup.geojson"
+    lac_path = paths.data_lookup / "lsoa_2011_2021_lookup.csv"
+
+    logger.info("processing geography data", source=str(input_path))
+
+    with open(input_path, "r", encoding="utf-8") as f:
+        geojson_data = json.load(f)
+
+    features = geojson_data.get("features", [])
+
+
+    rows = []
+    for feat in features:
+        props = feat.get("properties") or feat.get("attributes") or {}
+       
+        geom = feat.get("geometry")
+        if geom:
+            # Save geometry as JSON string with "coordinates" key
+            props["geo_shape"] = json.dumps({"coordinates": geom.get("rings")})
+       
+        rows.append(props)
+
+
+    # 4️⃣ Convert to DataFrame
+    full_df = pl.DataFrame(rows)
+
+    pl.Config.set_tbl_cols(-1)
+    print(full_df.head())
+    print(full_df.columns)
+
+
+
+    lac_filter = pl.read_csv(lac_path).filter(pl.col("local_authority_code").is_in(local_authorities)).select(pl.col("lsoa_code_21").alias("lsoa_code"), pl.col("local_authority_code"))
+    
+    
+    df = full_df.join(lac_filter, left_on="LSOA21CD", right_on="lsoa_code", how="inner")
+
+
+
+    print(df.head())
+    print(df.shape)
+
+
+
+
+    df = df.select([
+        pl.col("LSOA21CD").alias("lsoa_code"),
+        pl.col("LAT").alias("latitude"),
+        pl.col("LONG").alias("longitude"),
+        pl.col("geo_shape"),
+        pl.col("local_authority_code")
+    ])
+
+    print(df.head())
+
+    return df.lazy().sink_csv(paths.data_lookup / "geography_lookup_new.csv")
+
+# for reference, the original code was:
+def process_old() -> pl.LazyFrame:
     logger.info("processing geography lookup data", source=str(paths.data_raw / "lookup" / "geography_lookup.parquet"))
     return (
         pl.scan_parquet(paths.data_raw / "lookup" / "geography_lookup.parquet")
@@ -23,4 +88,4 @@ def process() -> pl.LazyFrame:
 
 
 if __name__ == '__main__':
-    process()
+    process(local_authorities=["E06000023"])

--- a/imd_pipeline/process/open_street_map.py
+++ b/imd_pipeline/process/open_street_map.py
@@ -280,7 +280,7 @@ def format_osm_geodataframes(
 
 
 def get_polygon(x) -> Polygon:
-    return Polygon(json.loads(x).get("coordinates")[0][0])
+    return Polygon(json.loads(x).get("coordinates")[0])
 
 
 def process(persist_processed_file: bool = False, snapshot_date: str | None = None) -> pl.LazyFrame:

--- a/imd_pipeline/process/open_street_map.py
+++ b/imd_pipeline/process/open_street_map.py
@@ -280,7 +280,7 @@ def format_osm_geodataframes(
 
 
 def get_polygon(x) -> Polygon:
-    return Polygon(json.loads(x).get("coordinates")[0])
+    return Polygon(json.loads(x).get("coordinates")[0][0])
 
 
 def process(persist_processed_file: bool = False, snapshot_date: str | None = None) -> pl.LazyFrame:

--- a/main.py
+++ b/main.py
@@ -26,14 +26,14 @@ def main():
     )
 
     # fetch and process lookup data
+    fetch.lsoa_2011_2021_lookup.fetch()
     fetch.geography_lookup.fetch()
     fetch.postcode_lookup.fetch()
-    fetch.lsoa_2011_2021_lookup.fetch()
     fetch.population_lookup.fetch()
     logger.info("lookup data fetch complete")
+    process.lsoa_2011_2021_lookup.process()
     process.geography_lookup.process()
     process.postcode_lookup.process()
-    process.lsoa_2011_2021_lookup.process()
     population_data = process.population_lookup.process(persist_processed_file=True)
     logger.info("lookup data process complete")
 


### PR DESCRIPTION
This PR is in aid of extending data fetching to other UK cities.

Unfortunately, no country-wide geo shapes file was found. This meant using the ONS' arcgis API instead. The API cannot be queried for a full dataset, being limited to 2000 rows or less depending on given parameters. To accommodate for this, relating Object IDs are fetched first instead and then data is fetched in batches - as per the instruction laid in the API documentation.

Following this, processing had to be amended to accommodate for the new file type. The goal here was to produce the same geo-lookup file as before so that no scripts using the lookup file break. This is done except for some features are not included because upon inspecting the pipeline they have been found to be redundant. These being: northing, easting and geo_point.