### PR TITLE
bugfix/police uk zip unpacking

### DIFF
--- a/imd_pipeline/fetch/police_uk.py
+++ b/imd_pipeline/fetch/police_uk.py
@@ -18,7 +18,7 @@ from ratelimit import limits
 from shapely.geometry import Polygon, shape
 
 from imd_pipeline.utils.http import create_session
-from imd_pipeline.utils.lsoas import get_district_slug, get_target_codes
+from imd_pipeline.utils.lsoas import convert_2011_to_2021, get_district_slug, get_target_codes
 from imd_pipeline.utils.timeframes import get_window_bounds, months_in_window
 
 STREETLEVEL_URL = "https://data.police.uk/api/crimes-street/all-crime"
@@ -369,7 +369,7 @@ def produce_monthly_outputs(district_name: str, zip_path: Path, force_refresh: b
                     street_df = pl.read_csv(f)
                     street_dfs.append(street_df)
 
-            street_df = pl.concat(street_dfs, how="vertical")
+            street_df: pl.DataFrame = pl.concat(street_dfs, how="vertical")
             street_df = street_df.drop_nulls(subset="Crime ID")
 
             if files["outcomes"]:
@@ -379,23 +379,35 @@ def produce_monthly_outputs(district_name: str, zip_path: Path, force_refresh: b
                         outcomes_df = pl.read_csv(f)
                         outcome_dfs.append(outcomes_df)
 
-                outcomes_df = pl.concat(outcome_dfs, how="vertical")
+                outcomes_df: pl.DataFrame = pl.concat(outcome_dfs, how="vertical")
                 outcomes_df = outcomes_df.drop_nulls(subset=["Crime ID"])
 
                 merged = street_df.join(outcomes_df, on="Crime ID", how="left")
             else:
                 merged = street_df
 
-            merged = merged.filter(pl.col("LSOA code").is_in(target_codes)).with_columns(pl.lit(month).alias("month"))
-
-            merged.select(
-                [
-                    "month",
-                    pl.col("Crime type").alias("category"),
-                    pl.col("LSOA code").alias("lsoa_code"),
-                    pl.col("Outcome type").alias("outcome_status"),
-                ]
-            ).write_parquet(paths.data_raw / district_slug / "police_uk" / f"{month}.parquet")
+            merged = (
+                (
+                    merged.lazy()
+                    .pipe(
+                        convert_2011_to_2021,
+                        col="LSOA code",
+                        lookup_path=paths.data_reference / "lsoa_2011_2021_lookup.csv",
+                    )
+                    .filter(pl.col("LSOA code").is_in(target_codes))
+                    .with_columns(pl.lit(month).alias("month"))
+                )
+                .select(
+                    [
+                        "month",
+                        pl.col("Crime type").alias("category"),
+                        pl.col("LSOA code").alias("lsoa_code"),
+                        pl.col("Outcome type").alias("outcome_status"),
+                    ]
+                )
+                .collect()
+                .write_parquet(paths.data_raw / district_slug / "police_uk" / f"{month}.parquet")
+            )
 
 
 def fetch_bulk_csv(

--- a/imd_pipeline/fetch/police_uk.py
+++ b/imd_pipeline/fetch/police_uk.py
@@ -7,11 +7,11 @@ from pathlib import Path
 from urllib.parse import urljoin
 
 import geopandas as gpd
-from geopolars.datasets import available
 import polars as pl
 import requests
 from bs4 import BeautifulSoup as bs
 from dateutil.relativedelta import relativedelta
+from geopolars.datasets import available
 from loguru import logger
 from project_paths import paths
 from ratelimit import limits
@@ -282,11 +282,7 @@ def build_dataset_index() -> dict:
     return dict(sorted(dataset_index.items(), reverse=True))
 
 
-def fetch_url_from_dates(
-    newest_date: datetime,
-    oldest_date: datetime,
-    dataset_index: dict
-) -> list[str]:
+def fetch_url_from_dates(newest_date: datetime, oldest_date: datetime, dataset_index: dict) -> list[str]:
     """
     Find the specific download links needed to fulfill the respective given data range.
 
@@ -343,34 +339,47 @@ def produce_monthly_outputs(district_name: str, zip_path: Path, force_refresh: b
     target_codes = get_target_codes(district_name)
     # TODO: clean up this function, not particurlalry readable
 
+    monthly_files = defaultdict(dict)
+
     # Get paths to reqauired files
     with zipfile.ZipFile(zip_path, "r") as z:
-        monthly_files = defaultdict(dict)
-
         for file in z.namelist():
             month = file.split("/")[0]
+
+            if not monthly_files.get(month):
+                monthly_files[month]["street"] = []
+                monthly_files[month]["outcomes"] = []
+
             if not force_refresh:
                 month_path = paths.data_raw / get_district_slug(district_name) / "police_uk" / f"{month}.parquet"
                 if month_path.exists():
                     continue
             if "street" in file:
-                monthly_files[month]["street"] = file
+                monthly_files[month]["street"].append(file)
             elif "outcomes" in file:
-                monthly_files[month]["outcomes"] = file
+                monthly_files[month]["outcomes"].append(file)
 
         for month, files in monthly_files.items():
-            if "street" not in files:
+            if not files["street"]:
                 continue
 
-            with z.open(files["street"]) as f:
-                street_df = pl.read_csv(f)
+            street_dfs = []
+            for file in files["street"]:
+                with z.open(file) as f:
+                    street_df = pl.read_csv(f)
+                    street_dfs.append(street_df)
 
+            street_df = pl.concat(street_dfs, how="vertical")
             street_df = street_df.drop_nulls(subset="Crime ID")
 
-            if "outcomes" in files:
-                with z.open(files["outcomes"]) as f:
-                    outcomes_df = pl.read_csv(f)
+            if files["outcomes"]:
+                outcome_dfs = []
+                for file in files["outcomes"]:
+                    with z.open(file) as f:
+                        outcomes_df = pl.read_csv(f)
+                        outcome_dfs.append(outcomes_df)
 
+                outcomes_df = pl.concat(outcome_dfs, how="vertical")
                 outcomes_df = outcomes_df.drop_nulls(subset=["Crime ID"])
 
                 merged = street_df.join(outcomes_df, on="Crime ID", how="left")
@@ -390,11 +399,7 @@ def produce_monthly_outputs(district_name: str, zip_path: Path, force_refresh: b
 
 
 def fetch_bulk_csv(
-    newest_date: datetime,
-    oldest_date: datetime,
-    district_name: str,
-    dataset_index: dict,
-    force_refresh: bool = False
+    newest_date: datetime, oldest_date: datetime, district_name: str, dataset_index: dict, force_refresh: bool = False
 ):
     """This is the main function for fetching by bulk csv download. Once the download url assosciated with the desired
     csvs are found, loops through the list of urls for data fetching and processing. Once all processes are done, the large
@@ -405,7 +410,6 @@ def fetch_bulk_csv(
         oldest_date: The oldes requested date
         district_name: Name of local authority to fetch from
         dataset_index: Dictionary of start, end dates and download link extensions"""
-
 
     # TODO: Add logic to recognise if files already downloaded, add relevance to force_refresh
 
@@ -462,7 +466,6 @@ def fetch(district_name: str, snapshot_date="2025-12-01", window_months=12, forc
 
     # check cache hit
     if not force_refresh:
-
         for month in months_requested:
             month_path = paths.data_raw / get_district_slug(district_name) / "police_uk" / f"{month}.parquet"
 
@@ -490,17 +493,17 @@ def fetch(district_name: str, snapshot_date="2025-12-01", window_months=12, forc
 
     if newest_date_to_fetch == None:
         logger.debug("all requested police uk data found in cache")
-        return 
+        return
 
     logger.debug(f"police uk data available from {min_avail} to {max_avail}")
     logger.debug(f"newest date to fetch after trimming: {newest_date_to_fetch}")
     logger.debug(f"oldest date to fetch after trimming: {oldest_date_to_fetch}")
     logger.debug(f"api date limit: {api_date_limit}")
 
-    api_fetch_threshold = 2 # number of months to fetch via API
+    api_fetch_threshold = 2  # number of months to fetch via API
 
     # fetch with just api
-    
+
     if api_fetch_threshold >= len(months_to_fetch):
         fetch_api(
             snapshot_date=str(newest_date_to_fetch),
@@ -511,7 +514,6 @@ def fetch(district_name: str, snapshot_date="2025-12-01", window_months=12, forc
 
     # fetch partially with api
     elif newest_date_to_fetch >= api_date_limit:
-
         """Note: we are not considering using a ceiling because we have already ensured all dates are
         changed to the 1st of the month."""
 

--- a/imd_pipeline/fetch/police_uk.py
+++ b/imd_pipeline/fetch/police_uk.py
@@ -366,7 +366,7 @@ def produce_monthly_outputs(district_name: str, zip_path: Path, force_refresh: b
             street_dfs = []
             for file in files["street"]:
                 with z.open(file) as f:
-                    street_df = pl.read_csv(f)
+                    street_df = pl.read_csv(f, infer_schema=False)
                     street_dfs.append(street_df)
 
             street_df: pl.DataFrame = pl.concat(street_dfs, how="vertical")
@@ -376,7 +376,7 @@ def produce_monthly_outputs(district_name: str, zip_path: Path, force_refresh: b
                 outcome_dfs = []
                 for file in files["outcomes"]:
                     with z.open(file) as f:
-                        outcomes_df = pl.read_csv(f)
+                        outcomes_df = pl.read_csv(f, infer_schema=False)
                         outcome_dfs.append(outcomes_df)
 
                 outcomes_df: pl.DataFrame = pl.concat(outcome_dfs, how="vertical")
@@ -392,7 +392,7 @@ def produce_monthly_outputs(district_name: str, zip_path: Path, force_refresh: b
                     .pipe(
                         convert_2011_to_2021,
                         col="LSOA code",
-                        lookup_path=paths.data_reference / "lsoa_2011_2021_lookup.csv",
+                        lookup_path=paths.data_lookup / "lsoa_2011_2021_lookup.csv",
                     )
                     .filter(pl.col("LSOA code").is_in(target_codes))
                     .with_columns(pl.lit(month).alias("month"))
@@ -549,10 +549,11 @@ def fetch(district_name: str, snapshot_date="2025-12-01", window_months=12, forc
     # date range not covered by api, only
     else:
         fetch_bulk_csv(
-            newest_date_to_fetch,  # type: ignore
-            oldest_date_to_fetch,  # type: ignore
-            district_name,
-            force_refresh,
+            newest_date=newest_date_to_fetch,  # type: ignore
+            oldest_date=oldest_date_to_fetch,  # type: ignore
+            district_name=district_name,
+            dataset_index=dataset_index,
+            force_refresh=force_refresh,
         )
 
 

--- a/imd_pipeline/fetch/police_uk.py
+++ b/imd_pipeline/fetch/police_uk.py
@@ -26,6 +26,23 @@ ARCHIVE_URL = "https://data.police.uk/data/archive/"
 MAX_MONTHS = 36
 
 
+CSV_TO_API_CATEGORIES = {
+    "Bicycle theft": "bicycle-theft",
+    "Burglary": "burglary",
+    "Criminal damage and arson": "criminal-damage-arson",
+    "Drugs": "drugs",
+    "Other crime": "other-crime",
+    "Other theft": "other-theft",
+    "Possession of weapons": "possession-of-weapons",
+    "Public order": "public-order",
+    "Robbery": "robbery",
+    "Shoplifting": "shoplifting",
+    "Theft from the person": "theft-from-the-person",
+    "Vehicle crime": "vehicle-crime",
+    "Violence and sexual offences": "violent-crime",
+}
+
+
 def extract_largest_polygon(geom) -> Polygon:
     """Returns the largest polygon from a geometry, or the input if already a Polygon.
 
@@ -400,7 +417,7 @@ def produce_monthly_outputs(district_name: str, zip_path: Path, force_refresh: b
                 .select(
                     [
                         "month",
-                        pl.col("Crime type").alias("category"),
+                        pl.col("Crime type").replace(CSV_TO_API_CATEGORIES).alias("category"),
                         pl.col("LSOA code").alias("lsoa_code"),
                         pl.col("Outcome type").alias("outcome_status"),
                     ]

--- a/imd_pipeline/process/police_uk.py
+++ b/imd_pipeline/process/police_uk.py
@@ -47,9 +47,7 @@ CRIME_OUTCOMES = [
 def _valid_names(window_months: int, snapshot_date: str) -> frozenset[str]:
     """Cached helper for file_in_window - precomputes the set of valid month filenames for a time window."""
     # want to use a set for quick membership check, but cache requires a hashable object, so a frozenset is used
-    return frozenset(
-        f"{month}.parquet" for month in months_in_window(snapshot_date, window_months)
-    )
+    return frozenset(f"{month}.parquet" for month in months_in_window(snapshot_date, window_months))
 
 
 def file_in_window(filename, window_months, snapshot_date) -> bool:
@@ -98,12 +96,8 @@ def aggregate_to_lsoa(lf: pl.LazyFrame) -> pl.LazyFrame:
 
 def derive_stats(lf: pl.LazyFrame) -> pl.LazyFrame:
     """Pipeable func - adds total_crimes (sum of category counts) and resolution_rate (outcomes / total_crimes)."""
-    return lf.with_columns(
-        pl.sum_horizontal(slt.by_name(CRIME_CATEGORIES)).alias("total_crimes")
-    ).with_columns(
-        (pl.sum_horizontal(slt.by_name(CRIME_OUTCOMES)) / pl.col("total_crimes")).alias(
-            "resolution_rate"
-        )
+    return lf.with_columns(pl.sum_horizontal(slt.by_name(CRIME_CATEGORIES)).alias("total_crimes")).with_columns(
+        (pl.sum_horizontal(slt.by_name(CRIME_OUTCOMES)) / pl.col("total_crimes")).alias("resolution_rate")
     )
 
 
@@ -132,9 +126,7 @@ def process(
         snapshot_date=snapshot_date,
     )
     dir = paths.data_raw / district_slug / "police_uk"
-    is_valid_file = partial(
-        file_in_window, window_months=window_months, snapshot_date=snapshot_date
-    )
+    is_valid_file = partial(file_in_window, window_months=window_months, snapshot_date=snapshot_date)
 
     files = [file for file in dir.glob("*.parquet") if is_valid_file(file.name)]
     logger.info("found files in window", count=len(files))
@@ -152,12 +144,8 @@ def process(
     )
 
     if persist_processed_file:
-        dataframe.sink_parquet(
-            paths.data_processed / district_slug / "police_uk.parquet"
-        )
-        logger.info(
-            "police data written", path=str(paths.data_processed / "police_uk.parquet")
-        )
+        dataframe.sink_parquet(paths.data_processed / district_slug / "police_uk.parquet")
+        logger.info("police data written", path=str(paths.data_processed / "police_uk.parquet"))
 
     return dataframe
 

--- a/imd_pipeline/utils/http.py
+++ b/imd_pipeline/utils/http.py
@@ -10,7 +10,7 @@ CHUNK_SIZE = 8192
 
 
 def create_session(
-    retries: int = 5,
+    retries: int = 10,
     backoff: float = 2,
     status_forcelist: list[int] | None = None,
 ) -> requests.Session:
@@ -30,6 +30,7 @@ def create_session(
         backoff_factor=backoff,
         status_forcelist=status_forcelist,
         respect_retry_after_header=True,
+        allowed_methods={"GET", "POST", "HEAD"},
     )
     session = requests.Session()
     session.mount("https://", HTTPAdapter(max_retries=retry))

--- a/imd_pipeline/utils/lsoas.py
+++ b/imd_pipeline/utils/lsoas.py
@@ -23,12 +23,10 @@ def get_district_slug(district_name: str) -> str:
         >>> district_slug("Bournemouth, Christchurch and Poole")
         'bournemouth_christchurch_and_poole'
     """
-    return district_name.replace(" ", "_").lower().strip("_")
+    return district_name.replace(" ", "_").lower().strip("_").replace(",", "")
 
 
-def filter_lsoas(
-    lf: pl.LazyFrame, code_col: str, district_name: str, geography_path: Path
-) -> pl.LazyFrame:
+def filter_lsoas(lf: pl.LazyFrame, code_col: str, district_name: str, geography_path: Path) -> pl.LazyFrame:
     """Filters a Polars LazyFrame to region's LSOAs only.
 
     Args:
@@ -60,9 +58,7 @@ def filter_lsoas(
     return result
 
 
-def convert_2011_to_2021(
-    lf: pl.LazyFrame, col: str, lookup_path: Path, by: str = "code"
-) -> pl.LazyFrame:
+def convert_2011_to_2021(lf: pl.LazyFrame, col: str, lookup_path: Path, by: str = "code") -> pl.LazyFrame:
     """Converts LSOA codes or names from the 2011 to 2021 classification.
 
     Args:
@@ -89,9 +85,7 @@ def convert_2011_to_2021(
     return result
 
 
-def map_lsoa_names_to_codes(
-    lf: pl.LazyFrame, name_col: str, lookup_path: Path
-) -> pl.LazyFrame:
+def map_lsoa_names_to_codes(lf: pl.LazyFrame, name_col: str, lookup_path: Path) -> pl.LazyFrame:
     """Replaces a column of 2021 LSOA names with their corresponding LSOA codes.
 
     Args:
@@ -114,9 +108,7 @@ def map_lsoa_names_to_codes(
     return result
 
 
-def map_postcode_to_lsoa_code(
-    lf: pl.LazyFrame, postcode_col: str, lookup_path: Path
-) -> pl.LazyFrame:
+def map_postcode_to_lsoa_code(lf: pl.LazyFrame, postcode_col: str, lookup_path: Path) -> pl.LazyFrame:
     """Replaces a postcode column with the corresponding LSOA code.
 
     Args:
@@ -130,6 +122,4 @@ def map_postcode_to_lsoa_code(
     logger.debug("mapping postcode to lsoa", on_col=postcode_col)
     mapping = pl.scan_csv(lookup_path).select("postcode", "lsoa_code")
 
-    return lf.join(mapping, how="left", left_on=postcode_col, right_on="postcode").drop(
-        postcode_col
-    )
+    return lf.join(mapping, how="left", left_on=postcode_col, right_on="postcode").drop(postcode_col)


### PR DESCRIPTION
After noticing that crime data was missing in a lot of the early parquets, a bug in the zip file unpacking was discovered. The zip file contains several files - one for each police force. This is looped through, but the data structure that existed only allowed for a single file to be recorded. It would be overwritten on each loop until only the final file remained in the dictionary. The code has been updated to keep track of a list of files, then concatenate these into a single data frame.

Additionally, we have added a conversion of lsoa codes to the up to date codes before filtering to avoid a chance that lsoas with a changed code would end up with no crimes because they did not exist in the archive data.

